### PR TITLE
Re-add function artifacts for function app.

### DIFF
--- a/Resources/AzureDevops/azure-pipelines.yml
+++ b/Resources/AzureDevops/azure-pipelines.yml
@@ -39,3 +39,12 @@ jobs:
       DotNetCoreVersion: 2.2.402
       PublishWebApp: true
       TestSuffix: UnitTests
+
+    # Build DFC.App.JobProfiles.HowToBecome.MessageFunctionApp
+  - template: AzureDevOpsTemplates/Build/dfc-dotnetcore-build-notests.yml@dfc-devops
+    parameters:
+      SolutionBaseName: $(SolutionBaseName).MessageFunctionApp
+      BuildPlatform: $(BuildPlatform)
+      BuildConfiguration: $(BuildConfiguration)
+      DotNetCoreVersion: 2.2.402
+      PublishWebApp: true


### PR DESCRIPTION
We don't need to run the unit tests as the sonarcloud build step should capture these